### PR TITLE
fix(server): correct go run behavior and add Makefile run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,8 @@ MIGRATIONS_DIR = ./db/migrations
 
 # ===== App =====
 run:
-	@PORT?=8081
-	@DATABASE_URL?=postgres://anima:anima@localhost:5432/anima?sslmode=disable
-	@echo "== Run API =="
-	PORT=$$PORT DATABASE_URL=$$DATABASE_URL go run .
+	@echo "Starting Anima..."
+	@set -a; [ -f .env ] && . ./.env; set +a; go run .
 
 
 # ===== Banco / migrações utilitárias =====


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the health check with context timeout and standardized JSON/status, and updates `make run` to source `.env` before `go run`.
> 
> - **Server**:
>   - **Health endpoint (`/health`)**: adds 2s context timeout with `db.PingContext`, sets JSON content type, returns explicit HTTP statuses with `{"status":"ok"|"error"}`.
>   - Logs: standardizes startup message to `"Listening on :<port>"`.
> - **Tooling**:
>   - **Makefile `run`**: sources `.env` automatically and starts app with `go run .`; prints "Starting Anima...".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01745f3d13b4176ca8624e31a03ac8301097e097. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->